### PR TITLE
Upgrade to clojure 1.9.0 and Lucene 7.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: clojure
 
-lein: lein2
+lein: lein
 
 jdk:
-  - openjdk7
-  - oraclejdk7
   - oraclejdk8
 
 after_script:

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
 (defproject com.otfrom/clucy "0.7.2.1"
   :description "A Clojure interface to the Lucene search engine"
   :url "http://github/kostafey/clucy"
-                 [org.apache.lucene/lucene-core "5.5.0"]
-                 [org.apache.lucene/lucene-queryparser "5.5.0"]
-                 [org.apache.lucene/lucene-analyzers-common "5.5.0"]
-                 [org.apache.lucene/lucene-highlighter "5.5.0"]
   :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.apache.lucene/lucene-core "7.2.1"]
+                 [org.apache.lucene/lucene-queryparser "7.2.1"]
+                 [org.apache.lucene/lucene-analyzers-common "7.2.1"]
+                 [org.apache.lucene/lucene-highlighter "7.2.1"]
                  [me.raynes/fs "1.4.6"]]
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/project.clj
+++ b/project.clj
@@ -9,4 +9,4 @@
                  [me.raynes/fs "1.4.6"]]
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :plugins [[lein-cloverage "1.0.6"]])
+  :plugins [[lein-cloverage "1.0.10"]])

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject com.otfrom/clucy "0.7.2.1"
   :description "A Clojure interface to the Lucene search engine"
-  :url "http://github/kostafey/clucy"
+  :url "http://github/otfrom/clucy"
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.apache.lucene/lucene-core "7.2.1"]
                  [org.apache.lucene/lucene-queryparser "7.2.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,15 +1,12 @@
-(defproject org.clojars.kostafey/clucy "0.5.5.0"
+(defproject com.otfrom/clucy "0.7.2.1"
   :description "A Clojure interface to the Lucene search engine"
   :url "http://github/kostafey/clucy"
-  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.apache.lucene/lucene-core "5.5.0"]
                  [org.apache.lucene/lucene-queryparser "5.5.0"]
                  [org.apache.lucene/lucene-analyzers-common "5.5.0"]
                  [org.apache.lucene/lucene-highlighter "5.5.0"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
                  [me.raynes/fs "1.4.6"]]
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :profiles {:1.6  {:dependencies [[org.clojure/clojure "1.6.0"]]}
-             :1.7  {:dependencies [[org.clojure/clojure "1.7.0"]]}
-             :1.8  {:dependencies [[org.clojure/clojure "1.8.0"]]}}
   :plugins [[lein-cloverage "1.0.6"]])

--- a/src/clucy/analyzers.clj
+++ b/src/clucy/analyzers.clj
@@ -4,8 +4,8 @@
   (:import
    (java.io InputStream)
    (java.nio.charset StandardCharsets)
-   (org.apache.lucene.analysis.util WordlistLoader
-                                    CharArraySet)
+   (org.apache.lucene.analysis WordlistLoader
+                               CharArraySet)
    (org.apache.lucene.util IOUtils)
    (org.apache.lucene.analysis.Analyzer$TokenStreamComponents)
    (org.apache.lucene.analysis Analyzer

--- a/src/clucy/core.clj
+++ b/src/clucy/core.clj
@@ -4,14 +4,13 @@
            (java.net URI)
            (org.apache.lucene.analysis Analyzer TokenStream)
            (org.apache.lucene.analysis.standard StandardAnalyzer)
-           (org.apache.lucene.document Document Field FieldType
-                                       Field$Index Field$Store Field$TermVector)
+           (org.apache.lucene.document Document Field FieldType Field$Store)
            (org.apache.lucene.index IndexWriter IndexReader Term
                                     IndexWriterConfig DirectoryReader FieldInfo
                                     IndexOptions)
            (org.apache.lucene.queryparser.classic QueryParser)
            (org.apache.lucene.search BooleanClause BooleanClause$Occur
-                                     BooleanQuery IndexSearcher Query ScoreDoc
+                                     BooleanQuery BooleanQuery$Builder IndexSearcher Query ScoreDoc
                                      Scorer TermQuery
                                      Explanation)
            (org.apache.lucene.search.highlight Highlighter QueryScorer
@@ -214,7 +213,7 @@
   [index & maps]
   (with-open [^IndexWriter writer (index-writer index)]
     (doseq [m maps]
-      (let [query (BooleanQuery.)]
+      (let [query (BooleanQuery$Builder.)]
         (doseq [[key value] m]
           (dorun (map #(.add query
                      (BooleanClause.
@@ -224,7 +223,7 @@
                       (if-not (vector? value)
                         [value]
                         value))))
-        (.deleteDocuments writer (into-array [query]))))))
+        (.deleteDocuments writer (into-array [(.build query)]))))))
 
 (defn- document->map
   "Turn a Document object into a map."


### PR DESCRIPTION
This is the bare minimum to get clucy running with clojure 1.9.0 and Lucene 7.2.1. 

The tests all pass. Thoughts on further refactoring would be the next step.